### PR TITLE
ci: run eco-goinfra bump for all branches

### DIFF
--- a/.github/workflows/bump-all-branches.yml
+++ b/.github/workflows/bump-all-branches.yml
@@ -1,0 +1,55 @@
+name: Bump eco-goinfra on all branches
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+permissions:
+  contents: read
+    
+jobs:
+  branches:
+    outputs:
+      branches: ${{ steps.intersect-branches.outputs.branches }}
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: List eco-gotests branches
+        id: gotests-branches
+        run: |
+          echo "branches=$(git ls-remote ${{ github.repositoryUrl }} refs/heads/main 'refs/heads/release-*' |
+          cut -f 2 |
+          sed -e 's/refs\/heads\///g' |
+          jq -Rsc 'split("\n") | map(select(length > 0))')" >> $GITHUB_OUTPUT
+      
+      - name: List eco-goinfra branches
+        id: goinfra-branches
+        run: |
+          echo "branches=$(git ls-remote git://github.com/openshift-kni/eco-goinfra.git refs/heads/main 'refs/heads/release-*' |
+          cut -f 2 |
+          sed -e 's/refs\/heads\///g' |
+          jq -Rsc 'split("\n") | map(select(length > 0))')" >> $GITHUB_OUTPUT
+      
+      - name: Intersect eco-gotests and eco-goinfra branches
+        id: intersect-branches
+        run: echo "branches=$(echo $GOTESTS_BRANCHES $GOINFRA_BRANCHES | jq -sc '.[0] - (.[0] - .[1])')" >> $GITHUB_OUTPUT
+        env:
+          GOTESTS_BRANCHES: ${{ steps.gotests-branches.outputs.branches }}
+          GOINFRA_BRANCHES: ${{ steps.goinfra-branches.outputs.branches }}
+
+  bump:
+    needs: [branches]
+
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: ${{ fromJson(needs.branches.outputs.branches) }}
+
+    permissions:
+      contents: write
+      pull-requests: write
+
+    uses: ./.github/workflows/eco-goinfra-bump.yml
+    with:
+      branch: ${{ matrix.branch }}

--- a/.github/workflows/eco-goinfra-bump.yml
+++ b/.github/workflows/eco-goinfra-bump.yml
@@ -1,13 +1,24 @@
 name: 'Eco-GoInfra Module Bump'
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "0 0 * * *"
+    inputs:
+      branch:
+        description: Branch to bump eco-goinfra on
+        required: true
+        default: main
+        type: string
+  workflow_call:
+    inputs:
+      branch:
+        description: Branch to bump eco-goinfra on
+        required: true
+        default: main
+        type: string
 permissions:
   contents: read
 jobs:
   main:
-    name: Eco-goinfra module bump
+    name: Eco-goinfra module bump on ${{ inputs.branch }}
 
     permissions:
       contents: write  # for peter-evans/create-pull-request to create branch
@@ -22,6 +33,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
 
       - name: Set up Go 1.23
         uses: actions/setup-go@v5
@@ -29,7 +42,10 @@ jobs:
           go-version: 1.23.6
 
       - name: Run sync script
-        run: make sync-eco-goinfra
+        run: |
+          go get github.com/openshift-kni/eco-goinfra@${{ inputs.branch }} &&
+          go mod tidy &&
+          go mod vendor
 
       - name: Create PR
         id: create-pr
@@ -39,10 +55,11 @@ jobs:
         with:
           commit-message: "deps: bump github.com/openshift-kni/eco-goinfra"
           author: ${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>
-          title: Bump eco-goinfra dependency
+          title: Bump eco-goinfra dependency on ${{ inputs.branch }}
+          base: ${{ inputs.branch }}
           branch: eco-goinfra-bump
           delete-branch: true
-          reviewers: achuzhoy,cdvultur,klaskosk,kononovn,trewest
+          # reviewers: achuzhoy,cdvultur,klaskosk,kononovn,trewest
 
   ci:
     needs: main
@@ -61,6 +78,7 @@ jobs:
 
     steps:
       - name: Label PR based on CI result
-        run: gh pr edit ${{ needs.main.outputs.pr-url }} --add-label ci/${{ needs.ci.result }}
+        run: gh pr edit ${{ needs.main.outputs.pr-url }} --add-label ci/$CI_RESULT
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CI_RESULT: ${{ needs.ci.result == 'success' && 'success' || 'failure' }}


### PR DESCRIPTION
This PR updates the existing eco-goinfra-bump to take a branch input and remove the schedule. Instead, a new workflow has been added on a schedule that gets all branches on both eco-gotests and eco-goinfra and runs the bump against branches that exist on both.